### PR TITLE
Upgrade to Muzei API 3.4

### DIFF
--- a/app/src/main/java/com/xinthink/muzei/photos/SettingsActivity.kt
+++ b/app/src/main/java/com/xinthink/muzei/photos/SettingsActivity.kt
@@ -23,8 +23,8 @@ class SettingsActivity : AppCompatActivity() {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        return when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
             android.R.id.home -> {
                 onBackPressed()
                 true

--- a/buildSrc/src/main/java/deps.kt
+++ b/buildSrc/src/main/java/deps.kt
@@ -7,12 +7,12 @@ import java.net.URI
  * Dependency versions
  */
 object V {
-    const val compileSdkVersion = 28
+    const val compileSdkVersion = 30
     const val targetSdkVersion = 28
     const val minSdkVersion = 19
-    const val androidPluginVersion = "3.5.3"
+    const val androidPluginVersion = "4.0.1"
 
-    const val kotlinVersion = "1.3.50"
+    const val kotlinVersion = "1.3.72"
     const val ktStdlib = "stdlib-jdk7"
     const val coroutinesVersion = "1.3.3"
     const val ankoVersion = "0.10.8"
@@ -38,7 +38,7 @@ object V {
     const val picassoVersion = "2.71828"
     const val picassoTransformationsVersion = "2.2.1"
     const val workManagerVersion = "2.2.0"
-    const val muzeiApiVersion = "3.2.0"
+    const val muzeiApiVersion = "3.4.0"
     const val gmsAuthVersion = "16.0.1"
 
     const val ktlintVersion = "0.34.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 10 11:19:18 CST 2019
+#Sun Jul 26 14:57:29 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/muzeiPhotos/src/main/java/com/xinthink/muzei/photos/PhotosPruneReceiver.kt
+++ b/muzeiPhotos/src/main/java/com/xinthink/muzei/photos/PhotosPruneReceiver.kt
@@ -1,0 +1,26 @@
+package com.xinthink.muzei.photos
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.google.android.apps.muzei.api.provider.ProviderContract
+import com.xinthink.muzei.photos.worker.BuildConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+class PhotosPruneReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        // Run the prune on the IO dispatcher so that we
+        // don't block the main thread
+        val result = goAsync()
+        GlobalScope.launch(Dispatchers.IO) {
+            val providerClient = ProviderContract.getProviderClient(
+                context, BuildConfig.PHOTOS_AUTHORITY
+            )
+            providerClient.setArtwork(emptyList())
+            result.finish()
+            context.clearPageTokens()
+        }
+    }
+}

--- a/muzeiPhotos/src/main/java/com/xinthink/muzei/photos/PhotosWorker.kt
+++ b/muzeiPhotos/src/main/java/com/xinthink/muzei/photos/PhotosWorker.kt
@@ -94,14 +94,14 @@ class PhotosWorker(
             // .filter { it.mimeType.startsWith("image") }
             .map {
                 if (BuildConfig.DEBUG) Log.d(TAG, "adding MediaItem: $it")
-                Artwork().apply {
-                    token = it.id
-                    attribution = it.mediaMetadata?.formattedCreationTime()
-                    title = if (it.description?.isNotEmpty() == true) it.description else defaultDesc
-                    byline = it.contributorInfo?.displayName
-                    persistentUri = "${it.baseUrl}=d".toUri()
+                Artwork(
+                    token = it.id,
+                    attribution = it.mediaMetadata?.formattedCreationTime(),
+                    title = if (it.description?.isNotEmpty() == true) it.description else defaultDesc,
+                    byline = it.contributorInfo?.displayName,
+                    persistentUri = "${it.baseUrl}=d".toUri(),
                     webUri = it.productUrl.toUri()
-                }
+                )
             })
         return Result.success()
     }


### PR DESCRIPTION
Muzei API 3.4 significantly improves the performance of `addArtwork` when adding multiple artwork (such as what `PhotosWorker` does, which got slightly updated to take into account the immutability of `Artwork` now).

Muzei API 3.4 depends on Kotlin 1.3.72 and a `compileSdkVersion` of 30, which enforced an upgrade to Android Gradle Plugin 4.0.1 (and with that, Gradle 6.5) and required a nullability fix in `SettingsActivity`.

The upgrade also affected how actions are implemented in `PhotosArtProvider` by deprecating the `getCommands()` and `onCommand()` methods (which are kept now only for backward compatibility with Muzei 3.3 users) and replacing them with the new `getCommandActions()` API, which uses `RemoteActionCompat` to handle commands using any type of component (in this case, using `PhotosPruneReceiver` as a `BroadcastReceiver` to do the small amount of work needed).